### PR TITLE
:construction: add uuid for audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 anyhow = { version = "1.0", optional = true }
 colored = { version = "2.1", optional = true }
 regex = "1.11"
+md5 = "0.7.0"
+aes = "0.8.4"
 
 [features]
 default = ["binary"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 anyhow = { version = "1.0", optional = true }
 colored = { version = "2.1", optional = true }
 regex = "1.11"
-aes = "0.8.4"
+aes = "0.8"
 
 [features]
 default = ["binary"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 anyhow = { version = "1.0", optional = true }
 colored = { version = "2.1", optional = true }
 regex = "1.11"
-md5 = "0.7.0"
 aes = "0.8.4"
 
 [features]

--- a/src/modules/audit.rs
+++ b/src/modules/audit.rs
@@ -1,4 +1,7 @@
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
+use ring::rand::{self, SecureRandom};
 use rune::{ContextError, Module};
+use md5;
 use std::{collections::HashMap, io};
 
 use once_cell::sync::Lazy;
@@ -9,7 +12,7 @@ static LEET_CHAR_TABLE: Lazy<HashMap<u8, Vec<u8>>> = Lazy::new(|| {
     map.insert(b'1', vec![b'1', b'l', b'I']);
     map.insert(b'2', vec![b'2', b'Z']);
     map.insert(b'3', vec![b'3']);
-    map.insert(b'4', vec![b'4', b'A']);
+    map.insert(b'4', vec![b'4']);
     map.insert(b'5', vec![b'5', b'S']);
     map.insert(b'6', vec![b'6', b'b']);
     map.insert(b'7', vec![b'7']);
@@ -69,6 +72,7 @@ static LEET_CHAR_TABLE: Lazy<HashMap<u8, Vec<u8>>> = Lazy::new(|| {
     map.insert(b'Z', vec![b'Z', b'z', b'2']);
     map.insert(b'_', vec![b'_', b'-']);
     map.insert(b'-', vec![b'-', b'_']);
+    map.insert(b'!', vec![b'!', b'1', b'l']);
 
     map
 });
@@ -234,8 +238,34 @@ pub fn decrypt_raw(data: &[u8], key: &str) -> Vec<u8> {
     )
 }
 
+/// Generate AES key and IV from a string
+///
+/// The function calculates the SHA-256 hash of the input string, and extracts
+/// two 16-bytes long data from the hash, treated as the AES key and IV.
+///
+/// # Arguments
+/// * `str` - The string to generate
+///
+/// # Example
+/// ```
+/// let (key, iv) = generate_aes_pair("some data");
+/// println!("Key: {:?}, IV: {:?}", key, iv);
+/// ```
+pub fn generate_aes_pair(str: &str) -> ([u8; 16], [u8; 16]) {
+    let hash = ring::digest::digest(&ring::digest::SHA256, str.as_bytes());
+    let key = hash.as_ref()[0..16].try_into().unwrap();
+    let iv = hash.as_ref()[16..32].try_into().unwrap();
+    (key, iv)
+}
+
 #[derive(Debug, Clone)]
 pub struct FlagStego {
+    pub key: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UUIDStego {
+    pub with_hyphen: bool,
     pub key: String,
 }
 
@@ -258,6 +288,10 @@ impl FlagStego {
 
     /// hide a number in flag string with key encrypted.
     pub fn leet(&self, template: &str, data: i64) -> String {
+        let stego = UUIDStego::new(&self.key, true);
+        let _ = stego.leet(template, data);
+
+
         let encrypted = encrypt_raw(&data.to_le_bytes(), &self.key);
         // turn the encrypted data into a i64
         let mut encrypted_slice = [0; 8];
@@ -317,6 +351,114 @@ impl FlagStego {
     }
 }
 
+impl UUIDStego {
+    /// Construct a UUIDStego instance.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// let uuid_stego = UUIDStego::new("some_key");
+    ///
+    /// let template = "hello_world";
+    /// let encrypted_flag = uuid_stego.leet(template, 114514); // -> encrypted flag
+    /// ```
+    pub fn new(key: &str, with_hyphen: bool) -> Self {
+        Self {
+            with_hyphen: with_hyphen,
+            key: key.to_string(),
+        }
+    }
+
+    /// hide a number in a uuid with key encrypted.
+    pub fn leet(&self, template: &str, data: i64) -> String {
+        let (aes_key, _) = generate_aes_pair(&self.key);
+        // dump template into md5 hash
+        let digest = md5::compute(&template.as_bytes());
+        let mut hash_slice = [0u8; 16];
+        hash_slice.copy_from_slice(&digest[0..16]);
+
+        // xor
+        let encrypted = encrypt_raw(&data.to_le_bytes(), &self.key);
+        // turn the encrypted data into a i64
+        let mut encrypted_slice = [0u8; 8];
+        encrypted_slice.copy_from_slice(&encrypted);
+        // generate random bytes (salt)
+        let rng = rand::SystemRandom::new();
+        let mut rand_bytes = [0u8; 4];
+        rng.fill(&mut rand_bytes).unwrap();
+        for i in 0..8 {
+            if i % 2 == 0 {
+                // we will reserve 4 bytes in order to check whether the
+                // flag is broken
+                hash_slice[i*2] ^= rand_bytes[i / 2];
+            }
+            hash_slice[i*2+1] ^= encrypted_slice[i];
+        }
+        // println!("hash: {:?}", hash_slice);
+
+        // aes ecb
+        let cipher = aes::Aes128::new_from_slice(&aes_key).unwrap();
+        let mut block = aes::Block::default();
+        block.copy_from_slice(&hash_slice);
+        cipher.encrypt_block(&mut block);
+
+        let mut result = String::new();
+        for i in 0..16 {
+            result.push_str(&format!("{:02x}", block[i]));
+            if self.with_hyphen && (i == 3 || i == 5 || i == 7 || i == 9) {
+                result.push('-');
+            }
+        }
+        // println!("result: {:?}", result);
+        result
+    }
+
+    pub fn unleet(&self, template: &str, data: &str) -> Result<i64, io::Error> {
+        let re = if self.with_hyphen {
+            regex::Regex::new(r"([0-9a-fA-F]{8})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{12})").unwrap()
+        } else {
+            regex::Regex::new(r"([0-9a-fA-F]{32})").unwrap()
+        };
+        let _ = re.captures(data).ok_or(io::Error::other("uuid format mismatch"))?;
+        let mut input_data = String::new();
+        for c in data.chars() {
+            if c != '-' {
+                input_data.push(c);
+            }
+        }
+        // println!("data: {:?}", data);
+        let data_slice = hex::decode(input_data).map_err(|_| io::Error::other("uuid format mismatch"))?;
+
+        let (aes_key, _) = generate_aes_pair(&self.key);
+        // aes ecb
+        let cipher = aes::Aes128::new_from_slice(&aes_key).unwrap();
+        let mut block = aes::Block::default();
+        block.copy_from_slice(&data_slice);
+        cipher.decrypt_block(&mut block);
+
+        // dump template into md5 hash
+        let digest = md5::compute(&template.as_bytes());
+        let mut hash_slice = [0u8; 16];
+        hash_slice.copy_from_slice(&digest[0..16]);
+
+        let mut dec = [0u8; 8];
+        for i in 0..8 {
+            if i % 2 != 0 {
+                // check whether the flag is broken
+                if hash_slice[i*2] != (block[i*2]) {
+                    return Err(io::Error::other("flag data broken"));
+                }
+            }
+            dec[i] = hash_slice[i*2+1] ^ block[i*2+1];
+        }
+
+        let decrypted = decrypt_raw(&dec, &self.key);
+        let mut decrypted_slice = [0u8; 8];
+        decrypted_slice.copy_from_slice(&decrypted);
+        Ok(i64::from_le_bytes(decrypted_slice))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,6 +473,20 @@ mod tests {
         let encrypted = flag_stego.leet(template, data);
         println!("Encrypted : {}", encrypted);
         let decrypted = flag_stego.unleet(template, &encrypted);
+        println!("Decrypted : {:?}", decrypted);
+        assert_eq!(decrypted.unwrap(), data);
+    }
+
+    #[test]
+    fn test_uuid_transform() {
+        let uuid_stego = UUIDStego::new("uuid_example_key", true);
+        let template = "Yes you are right but your should watch BanG Dream! It's MyGO!!!!!";
+        println!("Template  : {}", template);
+        let data = 1919810;
+        println!("User ID   : {}", data);
+        let encrypted = uuid_stego.leet(template, data);
+        println!("Encrypted : {}", encrypted);
+        let decrypted = uuid_stego.unleet(template, &encrypted);
         println!("Decrypted : {:?}", decrypted);
         assert_eq!(decrypted.unwrap(), data);
     }
@@ -349,6 +505,8 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
     let mut module = Module::from_meta(self::module_meta)?;
     module.function_meta(encode)?;
     module.function_meta(decode)?;
+    module.function_meta(encode_uuid)?;
+    module.function_meta(decode_uuid)?;
     Ok(module)
 }
 
@@ -388,4 +546,42 @@ pub fn encode(template: &str, key: &str, id: i64) -> String {
 pub fn decode(template: &str, key: &str, flag: &str) -> Result<i64, io::Error> {
     let flag_stego = FlagStego::new(key);
     flag_stego.unleet(template, flag)
+}
+
+/// encode the flag template and get the UUID with custom key.
+///
+/// In rune script:
+///
+/// ```rust
+/// use ret2api::audit;
+///
+/// pub fn environ(bucket, user, team) {
+///   Ok(#{
+///     FLAG: `flag{${audit::encode_uuid("yes_you_are_right_but_you_should_play_genshin_impact", "some_key", user.id)}}`
+///   })
+/// }
+/// ```
+#[rune::function]
+pub fn encode_uuid(template: &str, key: &str, id: i64, with_hyphen: bool) -> String {
+    let uuid_stego = UUIDStego::new(key, with_hyphen);
+    uuid_stego.leet(template, id)
+}
+
+/// Decrypt the data from flag (UUID format).
+///
+/// In rune script:
+///
+/// ```rust
+/// use ret2api::audit;
+///
+/// pub fn check(bucket, user, team, submission) {
+///   ...
+///   let decrypted_team_id = audit::decode_uuid("yes_you_are_right_but_you_should_play_genshin_impact", "some_key", "flag{53817ce7-bdbd-d49c-0c80-7fbdebbb625f}");
+///   ...
+/// }
+/// ```
+#[rune::function]
+pub fn decode_uuid(template: &str, key: &str, flag: &str, with_hyphen: bool) -> Result<i64, io::Error> {
+    let uuid_stego = UUIDStego::new(key, with_hyphen);
+    uuid_stego.unleet(template, flag)
 }

--- a/src/modules/audit.rs
+++ b/src/modules/audit.rs
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn test_uuid_transform() {
         let uuid_stego = UUIDStego::new("uuid_example_key", true);
-        let template = "Yes you are right but your should watch BanG Dream! It's MyGO!!!!!";
+        let template = "Yes you are right but you should watch BanG Dream! It's MyGO!!!!!";
         println!("Template  : {}", template);
         let data = 1919810;
         println!("User ID   : {}", data);

--- a/src/modules/audit.rs
+++ b/src/modules/audit.rs
@@ -288,10 +288,6 @@ impl FlagStego {
 
     /// hide a number in flag string with key encrypted.
     pub fn leet(&self, template: &str, data: i64) -> String {
-        let stego = UUIDStego::new(&self.key, true);
-        let _ = stego.leet(template, data);
-
-
         let encrypted = encrypt_raw(&data.to_le_bytes(), &self.key);
         // turn the encrypted data into a i64
         let mut encrypted_slice = [0; 8];


### PR DESCRIPTION
Addition to dynamic flag stego, makes the rune script able to generate dynamic flag in uuid format.

**Note** that the flag has random data injected and is different every time you call `audit::encode_uuid`.

There isn't any way to avoid importing new crate(s), since ring doesn't support AES-ECB (final data length of AES-GCM overflows) unless we implements by ourselves.

The example of Rune script are as follows:

```rust
use ret2api::audit;
use ret2api::utils;

/// whether the flag uuid contains hyphen (`-`)
const WITH_HYPHEN = true;
/// whether the flag uuid is case sensitive
const CASE_SENSITIVE  = true;
/// the key to initialize the flag encryptor
const ENCRYPT_KEY = "Ave mujija";
/// the flag prefix, maybe the game name, `flag` means the flag will be `flag{...}`
const PREFIX = "flag";
/// the flag template name, used to generate the correct flag content
const TEMPLATE = "Yes you are right but you should watch BanG Dream! It's MyGO!!!!!";

/// Check flag submitted by user.
///
/// * bucket: the challenge `ret2api::bucket::Bucket` object
/// * user: { id: number, account: string, institute_id: number }
/// * team: { id: Option<number>, name: Option<string>, institute_id: Option<number> }
/// * submission: { id: number, user_id: number, team_id: number, challenge_id: number, content: string }
///
/// Returns: Result<(bool, string, Option<{peer_team: i64, reason: string}>), any>
/// means (correct, msg, audit: { peer_team, reason }), when audit is not None, the team will be treated as cheated,
/// and the platform will publish a event to administrators.
///
/// The audit message will be validate again in the platform, so don't worry about false positives.
pub async fn check(bucket, user, team, submission) {
  let flag = utils::Flag::parse(submission.content)?;
  if flag.prefix() != PREFIX {
    return Ok((false, `Wrong format! flag should be ${PREFIX}{...}`, None))
  }

  if CASE_SENSITIVE && flag.content().chars().any(|c| c.is_uppercase()) {
    return Ok((false, "Incorrect!", None))
  }

  let enc_id = if let Some(id) = team.get("id") {
    id
  } else {
    user.id
  };

  // extract peer_team id.
  let dec_id = audit::decode_uuid(TEMPLATE, ENCRYPT_KEY, flag.content(), WITH_HYPHEN)?;
  if dec_id == enc_id {
    return Ok((true, "Correct!", None));
  }
  // the flag is wrong, let's see whether the team cheated
  if let Some(id) = team.get("id") {
    if dec_id != id {
      return Ok((false, "Incorrect!", Some(#{
        peer_team: dec_id,
        reason: `team ${team.id}:'${team.name}' may cheated with team ${dec_id}`
      })));
    }
  }

  Ok((false, "Incorrect!", None))
}

/// Provides the environment variables when user starts the challenge container.
///
/// *Note*: the flag content generation has random data injected every time you
/// call audit::encode_uuid. The examiners only validate the stegano data in the
/// flag content.
///
/// * bucket: the challenge `ret2api::bucket::Bucket` object
/// * user: { id: number, account: string, institute_id: number }
/// * team: { id: Option<number>, name: Option<string>, institute_id: Option<number> }
///
/// Returns: Result<#{ [key: string]: string }, any>
pub async fn environ(bucket, user, team) {
  let enc_id = if let Some(id) = team.get("id") {
    id
  } else {
    user.id
  };
  let content = audit::encode_uuid(TEMPLATE, ENCRYPT_KEY, enc_id, WITH_HYPHEN);
  Ok(#{
    FLAG: utils::Flag::new().with_prefix(PREFIX).with_content(content).to_string(),
  })
}
```

Run example:

```shell
$ cargo run environ ./dynamic-uuid.rn                                                
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s
     Running `target/debug/ret2scriptenviron ./dynamic-uuid.rn`
User            = {"account": "p1ay3r", "id": 3307, "institute_id": 1106}
Team            = {"id": 114514, "institute_id": 1106, "name": "te4m"}
---------------------------------------------
Result: {"FLAG": "flag{c35c9fb0-acfa-b26d-b6d2-0ce67a48951f}"}
```

```shell
$ cargo run check ./dynamic-uuid.rn --flag 'flag{c35c9fb0-acfa-b26d-b6d2-0ce67a48951f}'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.48s
     Running `target/debug/ret2script check ./dynamic-uuid.rn --flag flag{c35c9fb0-acfa-b26d-b6d2-0ce67a48951f}`
User            = {"account": "p1ay3r", "id": 3307, "institute_id": 1106}
Team            = {"id": 114514, "institute_id": 1106, "name": "te4m"}
Submission      = {"challenge_id": 810, "content": "flag{c35c9fb0-acfa-b26d-b6d2-0ce67a48951f}", "id": 1919, "team_id": 114, "user_id": 3307}
---------------------------------------------
Result
        Correct         = true
        Message         = Correct!
        Audit           = None
```

```shell
$ cargo run check ./dynamic-uuid.rn --flag 'flag{796ecd3e-1b4c-b91a-96c6-fbcf2ef1d382}'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.47s
     Running `target/debug/ret2scriptcheck ./dynamic-uuid.rn --flag flag{796ecd3e-1b4c-b91a-96c6-fbcf2ef1d382}`
User            = {"account": "p1ay3r", "id": 3307, "institute_id": 1106}
Team            = {"id": 114514, "institute_id": 1106, "name": "te4m"}
Submission      = {"challenge_id": 810, "content": "flag{796ecd3e-1b4c-b91a-96c6-fbcf2ef1d382}", "id": 1919, "team_id": 114, "user_id": 3307}
---------------------------------------------
Result
        Correct         = false
        Message         = Incorrect!
        Audit           = Some({"peer_team": 12345, "reason": "team 114514:'te4m' may cheated with team 12345"})
```